### PR TITLE
Fixed issue #3 and Changed default output directory

### DIFF
--- a/less2css.py
+++ b/less2css.py
@@ -38,7 +38,7 @@ class LessToCss:
     # set environment
     env = os.getenv('PATH')
     #if is not windows, modify system path
-    if platform.system != 'Windows':
+    if platform.system() != 'Windows':
       env = env + ':/usr/local/bin:/usr/local/sbin'
     os.environ['PATH'] = env
 


### PR DESCRIPTION
Fixed issue #3 and now it works on Mac OSX and Ubuntu, the reason that it didn't work  on Mac is that the PATH in the plugin execution-context is different with bash/shell, but I don't know why.

Also, I changed the default output directory from project root to the directory same as less file.
