### PR TITLE
outputdir fix and per project settings if available

### DIFF
--- a/less2css.py
+++ b/less2css.py
@@ -12,7 +12,8 @@ class MessageWindow:
     if message == '':
       return
 
-    settings = sublime.load_settings('less2css.sublime-settings')
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings('less2css.sublime-settings'))
     show_alert = settings.get("showErrorWithWindow", True)
 
     if show_alert == False:
@@ -63,7 +64,8 @@ class SetLessBaseCommand(sublime_plugin.WindowCommand):
   def set_less_setting(self, text):
     settings_base = 'less2css.sublime-settings'
 
-    settings = sublime.load_settings(settings_base)
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings(settings_base))
     
     if os.path.isdir(text):
       settings.set("lessBaseDir", text)
@@ -80,7 +82,8 @@ class SetOutputDirCommand(sublime_plugin.WindowCommand):
   def set_output_dir(self, text):
     settings_base = 'less2css.sublime-settings'
 
-    settings = sublime.load_settings(settings_base)
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings(settings_base))
     
     if os.path.isdir(text):
       settings.set("outputDir", text)
@@ -103,7 +106,8 @@ class toggleCssMinificationCommand(sublime_plugin.WindowCommand):
       minify_flag = True
 
     settings_base = 'less2css.sublime-settings'
-    settings = sublime.load_settings(settings_base)
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings(settings_base))
 
     if minify == -1:
       #input was cancelled, don't change

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -13,7 +13,8 @@ class Compiler:
     if not fn.endswith(".less"):
       return ''
 
-    settings = sublime.load_settings('less2css.sublime-settings')
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings('less2css.sublime-settings'))
     base_dir = settings.get("lessBaseDir")
     output_dir = settings.get("outputDir")
     output_file = settings.get("outputFile")
@@ -38,7 +39,8 @@ class Compiler:
     err_count = 0;
 
     #default_base
-    settings = sublime.load_settings('less2css.sublime-settings')
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings('less2css.sublime-settings'))
     base_dir = settings.get("lessBaseDir")
     output_dir = settings.get("outputDir")
     output_file = settings.get("outputFile")
@@ -84,7 +86,7 @@ class Compiler:
     else:
       css = re.sub('\.less$', '.css', less)
     
-    sub_path = css.replace(dirs['less'] + os.path.sep, '')
+    sub_path = os.path.basename(css)
     css = os.path.join(dirs['css'], sub_path)
 
     # create directories


### PR DESCRIPTION
Hi,
This fixes bug #29 and resolves the issue of not having settings per project. I noticed there's already a branch addressing this issue but changes were reverted. Anyway here's a much simpler solution. Hope you merge it to master, for me at least it works.
So, how to use it. Inside a project, go to project, edit project and add

``` json
"settings":
    {
        "less2css":
        {
            "autoCompile": true,
            "lessBaseDir": "./",
            "main_file": "myfile.less",
            "minify": true,
            "outputDir": "static/css",
            "outputFile": "",
            "showErrorWithWindow": false
        }
    }
```

In any case, if these settings are missing from the project settings the normal user settings are used.
