### PR TITLE
fixed outputdir and added tests

### DIFF
--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -85,10 +85,13 @@ class Compiler:
         css = outputFile
     else:
       css = re.sub('\.less$', '.css', less)
-    
-    sub_path = os.path.basename(css)
-    css = os.path.join(dirs['css'], sub_path)
 
+    if (dirs['same_dir']):
+      dirs['css'] = os.path.dirname(less)
+
+    sub_path = os.path.basename(css) # css file name
+    css = os.path.join(dirs['css'], sub_path)
+    
     # create directories
     output_dir = os.path.dirname(css)
     if not os.path.isdir(output_dir):
@@ -147,13 +150,14 @@ class Compiler:
     output_dir = '' if output_dir is None else output_dir
     fn = self.view.file_name().encode("utf_8")
     file_dir = os.path.dirname(fn)
-
+    
     # find project path
     # it seems that there is no shortcuts to get the active project folder,
     # it returns all, so need to find the active one
     proj_dir = ''
     window = sublime.active_window()
     proj_folders = window.folders()
+    
     for folder in proj_folders:
       if fn.startswith(folder):
         proj_dir = folder
@@ -163,9 +167,14 @@ class Compiler:
     if not base_dir.startswith('/'):
       base_dir = os.path.normpath(os.path.join(proj_dir, base_dir))
 
+    if output_dir == '' or output_dir == './':
+      same_dir = True
+    else:
+      same_dir = False
+
     # normalize css output base path
     if not output_dir.startswith('/'):
       output_dir = os.path.normpath(os.path.join(proj_dir, output_dir))
-    
-    return { 'project': proj_dir, 'less': base_dir, 'css' : output_dir }
+
+    return { 'project': proj_dir, 'less': base_dir, 'css' : output_dir, 'same_dir' : same_dir }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,146 @@
+import unittest
+import tempfile
+import sys, os
+
+# append the plugin dir to system path so we can import stuff
+sys.path.append(
+    os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+)
+
+# fake some modules
+class sublime:
+    class Dummy:
+        @staticmethod
+        def folders():
+            return [os.environ.get("test_project_dir")]
+    @staticmethod
+    def active_window():
+        return sublime.Dummy()
+
+
+class sublime_plugin:
+    pass
+
+sys.modules['sublime'] = sublime
+sys.modules['sublime_plugin'] = sublime_plugin
+
+from lesscompiler import Compiler
+
+# allways ./ ??
+BASE_DIR = './'
+LESS_FILE = "foo.less"
+CSS_FILE = "bar.css"
+
+"""
+Dummy view so we can instantiate the Compiler
+"""
+class DummyView:
+    def __init__(self, project_dir):
+        self.project_dir = project_dir
+
+    def file_name(self):
+        # less file to compile
+        return os.path.join(self.project_dir, LESS_FILE)
+
+
+class TestOuputDir(unittest.TestCase):
+    def setUp(self):
+        # create the project dir
+        self.project_dir = tempfile.mkdtemp()
+        os.environ['test_project_dir'] = self.project_dir
+        # the less file to compile
+        self.dummy_view = DummyView(self.project_dir)
+        # create the dummy less file
+        open(self.dummy_view.file_name(), 'w').close()
+        # the compiler
+        self.compiler = Compiler(self.dummy_view)
+        
+
+    def test_absolute_path_same_name(self):
+        print "Running %s" % self._testMethodName
+        # Providing an absolute path inside the project dir 
+        # because that's in tmp and we have write access
+        # but should work with any path
+        self.output = os.path.join(self.project_dir, 'absolute') # somthing like /tmp/tmpJshx/absolute
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output))
+        
+        # open the created file
+        with open(os.path.join(self.output, LESS_FILE.replace(".less", ".css")), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_absolute_path_provided_name(self):
+        print "Running %s" % self._testMethodName
+        # Providing an absolute path inside the project dir 
+        # because that's in tmp and we have write access
+        # but should work with any path
+        self.output = os.path.join(self.project_dir, 'absolute') # somthing like /tmp/tmpJshx/absolute
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output), outputFile=CSS_FILE)
+        
+        # open the created file
+        with open(os.path.join(self.output, CSS_FILE), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_relative_path_same_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = 'relative/path' # somthing like /tmp/tmpJshx/relative/path
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output))
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, LESS_FILE.replace(".less", ".css")), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_relative_path_provided_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = 'relative/path' # somthing like /tmp/tmpJshx/relative/path
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output), outputFile=CSS_FILE)
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, CSS_FILE), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_dot_path_same_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = './'
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output))
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, LESS_FILE.replace(".less", ".css")), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_dot_path_provided_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = './'
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output), outputFile=CSS_FILE)
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, CSS_FILE), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_empty_path_same_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = ''
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output))
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, LESS_FILE.replace(".less", ".css")), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+    def test_empty_path_provided_name(self):
+        print "Running %s" % self._testMethodName
+        self.output = ''
+        self.compiler.convertLess2Css(self.compiler.parseBaseDirs(BASE_DIR, self.output), outputFile=CSS_FILE)
+        
+        # open the created file
+        with open(os.path.join(self.project_dir, self.output, CSS_FILE), "r") as f:
+            self.assertIsInstance(f, file)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I hope this time will work!
I tested it on Ubuntu and Windows 7
If it fails this time too i don't know what to say, in my case, i can set outputDir as a  relative, absolute and ./ path
and i find the compiled css where it should be..
Also try to run the test in the tests folder. It tries all the possible outputDir type of paths using a temporary dir structure.
Thanks!
