### PR TITLE
Adding 'auto' option to 'outputDir'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
-# sublime-less2css with 'auto' basedir
-
-_**This is a fork of the original sublime-less2css project with added 'auto' functionality**_
-
-_Set `outputDir` to `auto` to let the plugin automatically find the correct outputDir._
-
-_For example, if your folder structure is `/project/assets/css/less` it will save it in `/project/assets/css/`.
-If your structure looks like this: `/project/assets/less` and you have a `css` folder in your `assets` folder, 
-it will save it there._
-
-
+# sublime-less2css
 
 Sublime Text 2 Plugin to compile less files to css on save
 Requires lessc installed on PATH


### PR DESCRIPTION
Hi,

I've added an `auto` option for the `outputDir` setting, I'm sending a pull request in case you find it helpful.

Basically there are two typical folder structures that people use with less files:
1. Less in `/projects/assets/less` and CSS in `/projects/assets/css`
2. Less in `/projects/assets/css/less` and CSS in `/projects/assets/css`

My changes essentially do the following: check whether the parent folder is `css`. If yes, compile it there. If not, check whether there is a `css` folder in the parent folder, if yes, save it in that folder.

(Apologies for having two unnecessary commits in the history, I added some changes to the README file and then reverted them)

Let me know if this is useful (it is for me and my dev team).
