### PR TITLE
Changes to the menu + set CSS output dir to 'auto'

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,6 +1,6 @@
 [
   {
-    "id": "project",
+    "id": "tools",
     "children":
     [
       {
@@ -10,7 +10,10 @@
         [
           { "command": "set_less_base", "caption": "Set less base directory"},
           { "command": "set_output_dir", "caption": "Set css output directory"},
+          { "command": "reset_less_base_auto", "caption": "Set css output directory to 'auto'"},
+          { "caption": "-" },
           { "command": "toggle_css_minification", "caption": "Toggle minify output css"},
+          { "caption": "-" },
           { "command": "less_to_css", "caption": "Compile this less file to css"},
           { "command": "all_less_to_css", "caption": "Compile all less in less base directory to css" }
         ]
@@ -29,8 +32,13 @@
         [
           {
             "caption": "Less2Css",
-            "children": 
+            "children":
             [
+              {   "command" : "open_file",
+                  "args": {"file": "${packages}/Less2Css/readme.md"},
+                  "caption": "Read me"
+              },
+              { "caption": "-" },
               {
                   "command": "open_file",
                   "args": {"file": "${packages}/Less2Css/less2css.sublime-settings"},
@@ -41,6 +49,7 @@
                   "args": {"file": "${packages}/User/less2css.sublime-settings"},
                   "caption": "Settings – User"
               },
+              { "caption": "-" },
               {
                   "command": "open_file",
                   "args": {

--- a/less2css.py
+++ b/less2css.py
@@ -82,6 +82,19 @@ class SetLessBaseCommand(sublime_plugin.WindowCommand):
       sublime.error_message("Entered directory does not exist")
 
 
+# set the css output folder to auto
+class ResetLessBaseAuto(sublime_plugin.WindowCommand):
+  def run(self):
+    settings_base = 'less2css.sublime-settings'
+
+    settings = sublime.active_window().active_view().settings() \
+      .get("less2css", sublime.load_settings(settings_base))
+    settings.set("outputDir", "auto")
+    sublime.save_settings(settings_base)
+
+    sublime.status_message("Output directory reset to auto")
+
+
 class SetOutputDirCommand(sublime_plugin.WindowCommand):
   def run(self):
     self.window.show_input_panel("Enter CSS Output Directory: ", "", lambda s: self.set_output_dir(s), None, None)


### PR DESCRIPTION
- Moved the menu from project to tools
- Added some dividers to make the menu a little easier to navigate
- Added a menu item for the read me
- Added a menu option to reset the CSS output dir to 'auto'
