### PR TITLE
Updated readme, added shadow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Less2Css requires lessc to compile less to css.
 2. Install npm([NodeJS Package Manager](https://npmjs.org/doc/README.html))
 3. Install less
 
-##
-    npm install less -gd
+	    npm install less -gd
 
 
 ### Windows
@@ -43,7 +42,7 @@ Less2Css requires lessc to compile less to css.
 The allowed values are *true* and *false*. When this setting is set to *true* the plugin will compile your LESS file each time you save it.
 
 ## lessBaseDir
-This folder is only used when compiling all LESS files at once through *Tools \ Less>Css \ Compile all less in less base directory to css*.
+This folder is only used when compiling all LESS files at once through *Tools \ Less>Css \ Compile all less in less base directory to css*. This can be an absolute path or a relative path. A relative path is useful when your projects always use the same structure, like a folder named *less* to keep all your LESS files in. When compiling all files at once it will also process all subfolders under the base folder.
 
 ## lesscCommand
 This setting can be used to specify a different compiler. When it is left empty the default compiler, named *lessc*, will be used.
@@ -56,14 +55,94 @@ The allowed values are *true* and *false*. When this setting is set to *true* th
 
 ## outputDir
 Use this setting to specify the folder where the CSS files will be placed. The following values are supported:
-- empty string or *./*
-    * Use an empty string or *./* to have the CSS file stored in the same folder as the LESS file.
-- absolute path
-    * specify an absolute path to the directory where the CSS file should be stored, eg /home/user/projects/site/assets/css
-- auto
-    * When your LESS files are stored in a folder called *css\less* the compiled CSS files will be placed in the *css* folder. **Be aware:** Any files stored in a subfolder of *css\less* will be saved to that same folder, ie: *css\less\common\global.less* will be compiled to *css\less\common\global.css*.
-    * When your LESS files are stored in a folder called *less* and its parent folder has a subfolder named *css* the compiled CSS files will be placed in the *css* folder. ie: *project\less\global.less* will be compiled to *project\css\global.css*.
-    * If neither of the two cases above have been met the CSS file will be stored in the same folder as the LESS file is in.
+
+### empty string or *./*
+Use an empty string or *./* to have the CSS file stored in the same folder as the LESS file.
+
+### absolute path
+Specify an absolute path to the directory where the CSS file should be stored, eg /home/user/projects/site/assets/css
+
+### relative path
+Specify a partial path to the directory where the CSS should be stored, eg ./css. This will store the CSS files in a folder CSS in the root of the project.
+
+### auto
+This setting is only recognized when saving or compiling a single file on command. It is **not** applied when building all LESS files through *Tools \ Less>Css \ Compile all less in less base directory to css*.This setting recognizes the following project setups:
+
+  - When your LESS files are stored in a folder called *css\less* the compiled CSS files will be placed in the *css* folder.
+
+  **Be aware:** Any files stored in a subfolder of *css\less* will **not** be saved in the *css* folder but in the same folder as its *less* counterpart:
+
+		[project]
+		    |- [css]
+		    |---- [less]
+		    |-------- [global]
+		    |------------ global.less
+		    |-------- site.less
+
+  Will result in the following after compilation:
+
+		[project]
+		    |- [css]
+		    |---- [less]
+		    |-------- [global]
+		    |------------ global.css
+		    |------------ global.less
+		    |-------- site.less
+		    |---- site.css
+
+  - When your LESS files are stored in a folder called *less* and its parent folder has a subfolder named *css* the compiled CSS files will be placed in the *css* folder.
+
+  **Be aware**: It is very important that the *css* folder already exists, else the *css* file will be stored in the same folder als its *less* counterpart.
+
+  **Be aware**: Any files stored in a subfolder of *less* will **not** be saved in the *css* folder but in the same folder as its *less* counterpart:
+
+		[project]
+		    |- [css]
+		    |- [less]
+		    |---- [global]
+		    |-------- global.less
+		    |---- site.less
+
+  Will result in the following after compilation:
+
+		[project]
+		    |- [css]
+		    |---- site.css
+		    |- [less]
+		    |---- [global]
+		    |-------- global.css
+		    |-------- global.less
+		    |---- site.less
+
+  - If neither of the two cases above have been met the CSS file will be stored in the same folder as the LESS file is in.
+
+### shadow
+
+When you specify *shadow* it is expected your LESS files are stored in a folder named *less*. Within this folder your are free to create any number of subfolder to organise your LESS files. When you compile a single file or all files through the menu command the string *less* will be replaced with *css* in the file path. For example, if you have this file structure:
+
+	[project]
+	    |- [less]
+	    |---- [global]
+	    |-------- global.less
+	    |---- [elements]
+	    |-------- header.less
+	    |---- site.less
+
+It will generate the same structure, only with css as its root folder like:
+
+	[project]
+	    |- [css]
+	    |---- [global]
+	    |-------- global.css
+	    |---- [elements]
+	    |-------- header.css
+	    |---- site.css
+	    |- [less]
+	    |---- [global]
+	    |-------- global.less
+	    |---- [elements]
+	    |-------- header.less
+	    |---- site.less
 
 ## outputFile
 When you specify an output file, this will be the file name used to compile **all** LESS files to. The content of the file will be overwritten after each compile. When you build all LESS file in the LESS base folder through *Tools \ Less>Css \ Compile all less in less base directory to css* you will only have the CSS of the last compiled file! Assign an empty string to have each LESS file compiled to its CSS counterpart, ie: site.less will become site.css.

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -108,6 +108,9 @@ class Compiler:
     if (dirs['same_dir']):
       # set the folder for the CSS file to the same folder as the LESS file
       dirs['css'] = os.path.dirname(less)
+    elif (dirs['shadow_folders']):
+      # replace less in the path with css, this will shadow the less folder structure
+      dirs['css'] = re.sub('less', 'css', os.path.dirname(less))
     # get the file name of the CSS file, including the extension
     sub_path = os.path.basename(css)  # css file name
     # combine the folder for the CSS file with the file name, this will be our target
@@ -190,7 +193,10 @@ class Compiler:
   #   - css (string)         = the normalised folder where the CSS file should be stored
   #   - sameDir (bool)       = True if the CSS file should be written to the same folder as where the
   #                            LESS file is located; otherwise False
+  #   - shadowFolders (bool) = True if the CSS files should follow the same folder structure as the LESS
+  #                            files.
   def parseBaseDirs(self, base_dir='./', output_dir=''):
+    shadow_folders = False
     # make sure we have a base and output dir before we continue. if none were provided
     # we will assign a default
     base_dir = './' if base_dir is None else base_dir
@@ -222,6 +228,9 @@ class Compiler:
       else:
         # we tried to automate it but failed
         output_dir = ''
+    elif output_dir == 'shadow':
+      shadow_folders = True
+      output_dir = re.sub('less', 'css', file_dir)
 
     # find project path
     # you can have multiple folders at the top level in a project but there is no way
@@ -254,4 +263,4 @@ class Compiler:
       output_dir = os.path.normpath(os.path.join(proj_dir, output_dir))
 
     # return the object with all the information that is needed to be determine where to leave the CSS file when compiling
-    return {'project': proj_dir, 'less': base_dir, 'css': output_dir, 'same_dir': same_dir}
+    return {'project': proj_dir, 'less': base_dir, 'css': output_dir, 'same_dir': same_dir, 'shadow_folders': shadow_folders}


### PR DESCRIPTION
- I've updated the readme with some 'graphical' examples and expanded the description of lessBaseDir
- I've added a new option for 'outputDir'. It will now also recognize 'shadow' as a valid option. This will recreate the LESS file structure for the CSS files.
