### PR TITLE
Fixed interaction between 'ignorePrefixedFiles' and 'main_file' settings

### DIFF
--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -67,7 +67,7 @@ class Compiler:
       return ''
 
     # check if files starting with an underscore should be ignored and if the file name starts with an underscore
-    if (settings['ignore_underscored'] and os.path.basename(fn).startswith('_') and is_auto_save):
+    if (settings['ignore_underscored'] and os.path.basename(fn).startswith('_') and is_auto_save and not settings['main_file']):
       # print a friendly message for the user
       print("[less2css] '" + fn + "' ignored, file name starts with an underscore and ignorePrefixedFiles is True")
       return ''


### PR DESCRIPTION
See issue #60

This fixes an issue where when `ignoredPrefixedFiles` is _true_ nothing is compiled, even if `main_file` is also specified. This seemed counter-intuitive and a bit confusing since the immediate assumption is that both must be set to _true_ to get the behaviour where `main_file` is compiled but not its imported files (usually prefixed with a '_'), which is actually achieved just by specifying `main_file`.

An alternate fix for this might be to change `ignoredPrefixedFiles` from a _boolean_ to a _string_ and have the user specify the prefix to ignore, with an empty string meaning not to ignore any files.
