### PR TITLE
Support for .min Addition

### DIFF
--- a/less2css.sublime-settings
+++ b/less2css.sublime-settings
@@ -15,6 +15,7 @@
   "outputDir": "./",
   "outputFile": "", //[example.css] if left blank uses same name of .less file
   "minify": true,
+  "minName": true,
   "autoCompile": true,
   "showErrorWithWindow": false,
   "main_file": false,

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -15,6 +15,7 @@ SETTING_IGNOREPREFIXEDFILES = "ignorePrefixedFiles"
 SETTING_LESSCCOMMAND = "lesscCommand"
 SETTING_MAINFILE = "main_file"
 SETTING_MINIFY = "minify"
+SETTING_MINNAME = "minName"
 SETTING_OUTPUTDIR = "outputDir"
 SETTING_OUTPUTFILE = "outputFile"
 
@@ -42,6 +43,7 @@ class Compiler:
         'lessc_command': project_settings.get(SETTING_LESSCCOMMAND, settings.get(SETTING_LESSCCOMMAND)),
         'main_file': project_settings.get(SETTING_MAINFILE, settings.get(SETTING_MAINFILE, False)),
         'minimised': project_settings.get(SETTING_MINIFY, settings.get(SETTING_MINIFY, True)),
+        'min_name': project_settings.get(SETTING_MINNAME, settings.get(SETTING_MINNAME, True)),
         'output_dir': project_settings.get(SETTING_OUTPUTDIR, settings.get(SETTING_OUTPUTDIR)),
         'output_file': project_settings.get(SETTING_OUTPUTFILE, settings.get(SETTING_OUTPUTFILE))
     }
@@ -120,6 +122,9 @@ class Compiler:
   def convertLess2Css(self, lessc_command, dirs, file='', minimised=True, outputFile=''):
     out = ''
 
+    # get the plugin settings
+    settings = self.getSettings()
+
     # get the current file & its css variant
     # if no file was specified take the file name if the current view
     if file == "":
@@ -139,7 +144,10 @@ class Compiler:
         css = outputFile
     else:
       # when no output file is specified we take the name of the less file and substitute .less with .css
-      css = re.sub('\.less$', '.css', less)
+      if settings['min_name']:
+        css = re.sub('\.less$', '.min.css', less)
+      else:
+        css = re.sub('\.less$', '.css', less)
 
     # Check if the CSS file should be written to the same folder as where the LESS file is
     if (dirs['same_dir']):


### PR DESCRIPTION
Added the ability for a user to enter true or false to add .min to their output file as it gets created.  For example, 
"styles.less" would turn into "styles.min.css" if this option was set to true.  This way, when you are ready to go to production and want to minify your CSS files you can also have it append the .min to your CSS.
