### PR TITLE
fixed issue chinese char in path on windows

### DIFF
--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -54,8 +54,12 @@ class Compiler:
     fn = self.view.file_name()
     # in Python 3 all string are Unicode by default, we only have to encode when running on something lower than 3
     # in addition Windows uses UTF-16 for its file names so we don't encode to UTF-8 on Windows
-    if sys.version_info < (3, 0, 0) and not platform.system() is "Windows":
-      fn = fn.encode("utf_8")
+    # but in Windows set system locale to Chinese(RPC) defalut filesystem encoding is "mbcs"
+    if sys.version_info < (3, 0, 0):
+      if platform.system() is "Windows":
+        fn = fn.encode(sys.getfilesystemencoding())
+      else:
+        fn = fn.encode("utf_8")
 
     # it the file isn't a less file we have no don't have to process it any further
     if not fn.endswith(".less"):


### PR DESCRIPTION
windows set non-unicode programs locale to chinese(rpc)
(system defalult coding is 'mbcs' not 'utf16')

Traceback (most recent call last):
  File ".\sublime_plugin.py", line 362, in run_
  File ".\less2css.py", line 45, in run
    resp = l2c.convertOne(is_auto_save=True)
  File ".\lesscompiler.py", line 85, in convertOne
    return self.convertLess2Css(settings['lessc_command'], dirs=dirs, file=fn, minimised=settings['minimised'], outputFile=settings['output_file'])
  File ".\lesscompiler.py", line 209, in convertLess2Css
    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File ".\subprocess.py", line 633, in **init**
  File ".\subprocess.py", line 842, in _execute_child
UnicodeEncodeError: 'ascii' codec can't encode characters in position 29-33: ordinal not in range(128)

so encode the file_path string with sys.getfilesystemencoding() is batter choice
