### PR TITLE
fix #54 on windows

### DIFF
--- a/less2css.py
+++ b/less2css.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
   from . import lesscompiler
 
+SETTING_SHOW_ALERT = "showErrorWithWindow"
 
 #message window
 class MessageWindow:
@@ -16,10 +17,11 @@ class MessageWindow:
   def show(self, message):
     if message == '':
       return
-
-    settings = sublime.active_window().active_view().settings() \
-      .get("less2css", sublime.load_settings('less2css.sublime-settings'))
-    show_alert = settings.get("showErrorWithWindow", True)
+    settings = sublime.load_settings('less2css.sublime-settings')
+    project_settings = sublime.active_window().active_view().settings().get("less2css")
+    if project_settings is None:
+      project_settings = {}
+    show_alert = project_settings.get(SETTING_SHOW_ALERT, settings.get(SETTING_SHOW_ALERT,True))
 
     if not show_alert:
       return

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -140,7 +140,7 @@ class Compiler:
       return ''
 
     # check if an output file has been specified
-    if outputFile != "":
+    if outputFile != "" and outputFile != None:
       # if the outputfile doesn't end on .css make sure that it does by appending .css
       if not outputFile.endswith(".css"):
         css = outputFile + ".css"


### PR DESCRIPTION
The changes below have fixed issue #54 on my (windows) machine.
An error occured while reading the showErrorWithWindow setting. 
I looked at the `lesscompiler.py` and applied the same method for reading settings

Of course, the popup will only appear if `showErrorWithWindow` is set to `true`

Thanks for you work,
