### PR TITLE
Make main_file to be relative to the less directory, rather than the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The allowed values are `true` and `false`. When this setting is `true` the plugi
 You can still compile the file through *Tools \ Less>Css \ Compile this less file to css* or the appropriate shortcut.
 
 ### main_file
-When you specify a main file only this file will get compiled when you save any LESS file. This is especially useful if you have one LESS file which imports all your other LESS files. Please note that this setting is only used when compiling a single LESS file and not when compiling all LESS files in the LESS base folder through *Tools \ Less>Css \ Compile all less in less base directory to css*.
+When you specify a main file only this file will get compiled when you save any LESS file. The location of this main file will be relative to the less base directory. This is especially useful if you have one LESS file which imports all your other LESS files. Please note that this setting is only used when compiling a single LESS file and not when compiling all LESS files in the LESS base folder through *Tools \ Less>Css \ Compile all less in less base directory to css*.
 
 ### minify
 The allowed values are `true` and `false`. When this setting is set to `true` the LESS compiler will be instructed to create a minified CSS file.

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -80,10 +80,10 @@ class Compiler:
 
     dirs = self.parseBaseDirs(settings['base_dir'], settings['output_dir'])
 
-    # if you've set the main_file (relative to current file), only that file gets compiled
+    # if you've set the main_file (relative to the less directory), only that file gets compiled
     # this allows you to have one file with lots of @imports
     if settings['main_file']:
-      fn = os.path.join(os.path.dirname(fn), settings['main_file'])
+      fn = os.path.join(dirs['less'], settings['main_file'])
 
     # compile the LESS file
     return self.convertLess2Css(settings['lessc_command'], dirs=dirs, file=fn, minimised=settings['minimised'], outputFile=settings['output_file'])


### PR DESCRIPTION
This is just a simple change to fix issue #58, and some of the issues that may be in #60

The main benefit of using the less directory rather than the current directory is so .less files in subfolders can trigger an update for the main_file.

and like kimsey0 said in his pull request please forgive me for not following any conventions regarding pull requests. This is also my first one, and I didn't know if there were anything I should have done before submitting it.