### PR TITLE
Default showErrorWithWindow to be true. Which seems the most logical option

### DIFF
--- a/less2css.sublime-settings
+++ b/less2css.sublime-settings
@@ -17,7 +17,7 @@
   "minify": true,
   "minName": false,
   "autoCompile": true,
-  "showErrorWithWindow": false,
+  "showErrorWithWindow": true,
   "main_file": false,
   "ignorePrefixedFiles": false
 }


### PR DESCRIPTION
The default value of showErrorWithWindow should be true.

Having the option defaulted as false mean if a file is incorrectly formatted the user will need to update the settings in order to debug. 
