### PR TITLE
align default settings with README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ When you specify a main file only this file will get compiled when you save any 
 ### minify
 The allowed values are `true` and `false`. When this setting is set to `true` the LESS compiler will be instructed to create a minified CSS file.
 
+### minName
+Minified name. default is `false`.
+
 ### outputDir
 Use this setting to specify the folder where the CSS files will be placed. The following values are supported:
 
-### empty string or `./`
+#### empty string or `./`
 Use an empty string or `./` to have the CSS file stored in the same folder as the LESS file.
 
 #### absolute path

--- a/less2css.sublime-settings
+++ b/less2css.sublime-settings
@@ -10,14 +10,14 @@
  */
 
 {
-  "lesscCommand": false,
+  "autoCompile": true,
   "lessBaseDir": "./",
-  "outputDir": "./",
-  "outputFile": "", //[example.css] if left blank uses same name of .less file
+  "lesscCommand": false,
+  "ignorePrefixedFiles": false,
+  "main_file": false,
   "minify": true,
   "minName": false,
-  "autoCompile": true,
-  "showErrorWithWindow": true,
-  "main_file": false,
-  "ignorePrefixedFiles": false
+  "outputDir": "./",
+  "outputFile": "", //[example.css] if left blank uses same name of .less file
+  "showErrorWithWindow": true
 }


### PR DESCRIPTION
ensures that while moving along down the README's documentation, coverage of each property setting matches the property list order of Sublime's User Settings object with matching respective layouts.

Aligning the order of documention with these properties should help make it a little easier and more efficient to cover the new content. Also for consistency add `minName` and stub out description.