### PR TITLE
fixed compress depreciation error by implementing less-plugin-clean-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Less2Css requires lessc to compile less to css.
 
 	    npm install less -gd
 
+4. Install less-plugin-clean-css
+
+        npm install -g less-plugin-clean-css
+
 
 ### Windows
 

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -181,7 +181,7 @@ class Compiler:
     # check if the compiler should create a minified CSS file
     if minimised:
       # create the command for calling the compiler
-      cmd = [lessc_command, less, css, "-x", "--verbose"]
+      cmd = [lessc_command, less, css, "--clean-css", "--verbose"]
       # when running on Windows we need to add an additional parameter to the call
       if platform_name == 'Windows':
         cmd[3] = '-compress'


### PR DESCRIPTION
I kept getting this error from less

"The compress option has been deprecated. We recommend you use a dedicated css minifier, for instance see less-plugin-clean-css."

The following changes fix that.
