### PR TITLE
minify flag depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Less2Css requires lessc to compile less to css.
 
 	    npm install less -gd
 
+4. Install less-plugin-clean-css
+
+        npm install -g less-plugin-clean-css
+
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Less2Css requires lessc to compile less to css.
 
 	    npm install less -gd
 
-4. Install less-plugin-clean-css
+4. Optional: To use minification you will need a minifier. Install less-plugin-clean-css or similar.
 
         npm install -g less-plugin-clean-css
 
@@ -65,7 +65,9 @@ You can still compile the file through *Tools \ Less>Css \ Compile this less fil
 When you specify a main file only this file will get compiled when you save any LESS file. This is especially useful if you have one LESS file which imports all your other LESS files. Please note that this setting is only used when compiling a single LESS file and not when compiling all LESS files in the LESS base folder through *Tools \ Less>Css \ Compile all less in less base directory to css*.
 
 ### minify
-The allowed values are `true` and `false`. When this setting is set to `true` the LESS compiler will be instructed to create a minified CSS file.
+Default: True
+The allowed values are `true`/`false` or a string which passes a minification option to lessc (e.g. `--clean-css`).
+When this setting is set to `true` the LESS compiler will be instructed to create a minified CSS file. The recommended less minifier is `npm install -g less-plugin-clean-css` which is a required dependancy when `minify=true`.
 
 ### outputDir
 Use this setting to specify the folder where the CSS files will be placed. The following values are supported:

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -181,7 +181,7 @@ class Compiler:
     # check if the compiler should create a minified CSS file
     if minimised:
       # create the command for calling the compiler
-      cmd = [lessc_command, less, css, "-x", "--verbose"]
+      cmd = [lessc_command, less, css, "--clean-css", "--verbose"]
       # when running on Windows we need to add an additional parameter to the call
       if platform_name == 'Windows':
         cmd[3] = '-compress'

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -179,12 +179,14 @@ class Compiler:
     # get the name of the platform (ie are we running on windows)
     platform_name = platform.system()
     # check if the compiler should create a minified CSS file
-    if minimised:
+    if bool(minimised):
       # create the command for calling the compiler
       cmd = [lessc_command, less, css, "--clean-css", "--verbose"]
       # when running on Windows we need to add an additional parameter to the call
       if platform_name == 'Windows':
-        cmd[3] = '-compress'
+        cmd[3] = '--clean-css'
+    elif type(minimised) is str:
+      cmd = [lessc_command, less, css, minimised, '--verbose']
     else:
       # the call for non minified CSS is the same on all platforms
       cmd = [lessc_command, less, css, "--verbose"]

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -178,19 +178,21 @@ class Compiler:
 
     # get the name of the platform (ie are we running on windows)
     platform_name = platform.system()
+
     # check if the compiler should create a minified CSS file
+    _minifier = None
     if bool(minimised):
-      # create the command for calling the compiler
-      cmd = [lessc_command, less, css, "--clean-css", "--verbose"]
-      # when running on Windows we need to add an additional parameter to the call
-      if platform_name == 'Windows':
-        cmd[3] = '--clean-css'
+      _minifier = '--clean-css'
     elif type(minimised) is str:
-      cmd = [lessc_command, less, css, minimised, '--verbose']
+      _minifier = minimised
+
+    if _minifier:
+      # create the command for calling the compiler
+      cmd = [lessc_command, less, css, _minifier, '--verbose']
+      print('[less2css] Using minifier : {}'.format(_minifier))
     else:
       # the call for non minified CSS is the same on all platforms
       cmd = [lessc_command, less, css, "--verbose"]
-
     print("[less2css] Converting " + less + " to " + css)
 
     # check if we're compiling with the default compiler


### PR DESCRIPTION
An enhancement of the NickWoodhams fix for less minificiation #105 #106  .

Minify option can now take true, false, or a string.
Default minify cmd is now --clean-css, when "string"
option is used a user define less minifier can be used.

Documentation has been updated around this change so
users know to install third party minifiers.

This command is also backwards compatible with users using older versions of Less2Css.