### PR TITLE
Fix #136 - main_file setting and relative paths

### DIFF
--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -134,10 +134,13 @@ class Compiler:
         # if you've set the main_file (relative to current file), only that file
         # gets compiled this allows you to have one file with lots of @imports
         if self.settings['main_file']:
-            self.file_name = os.path.join(
-                os.path.dirname(self.file_name),
-                self.settings['main_file']
-            )
+            if not os.path.isabs(self.settings['main_file']):
+                self.file_name = os.path.abspath(
+                    os.path.join(
+                        dirs['project'],
+                        self.settings['main_file']
+                    )
+                )
 
         # compile the LESS file
         return self.convertLess2Css(


### PR DESCRIPTION
It should be assumed relative paths are from project path else
having focus on another window will cause builds to fail / error

One solution to this issue is to use absolute paths which is not
very useful in team projects.