### PR TITLE
fixes #103 - Ruby less does not support verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Sublime Text 2 and 3 Plugin to compile less files to css on save. Requires lessc
 
 NB This plugin requires lessc to be in your execution path
 
+# Important notes:
+* If you have any issues raise them at : https://github.com/timdouglas/sublime-less2css/issues/
+* If using ruby less you will need to set `minify=false` and
+`disableVerbose=true` within your less2css settings. If you do not do this
+compiling of less files will not work.
+
 # Installation
 
 ## Install The Plugin
@@ -53,6 +59,11 @@ The allowed values are `true` and `false`. When this setting is set to `true` th
 
 ### createCssSourceMaps
 When `true` a css source map will be generated.
+
+## disableVerbose
+This option allows for the disabling of the verbose option which is used by
+default. The only time you might want / need to turn this off is then using
+the ruby gem less (which does not support --verbose).
 
 ### lessBaseDir
 This folder is only used when compiling all LESS files at once through *Tools \ Less>Css \ Compile all less in less base directory to css*. This can be an absolute path or a relative path. A relative path is useful when your projects always use the same structure, like a folder named `less` to keep all your LESS files in. When compiling all files at once it will also process all subfolders under the base folder.

--- a/less2css.sublime-settings
+++ b/less2css.sublime-settings
@@ -21,5 +21,6 @@
   "outputDir": "./",
   "outputFile": "", //[example.css] if left blank uses same name of .less file
   "showErrorWithWindow": true,
-  "autoprefix": false
+  "autoprefix": false,
+  "disableVerbose":false,
 }

--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -21,6 +21,7 @@ SETTING_OUTPUTDIR = "outputDir"
 SETTING_OUTPUTFILE = "outputFile"
 SETTING_CREATECSSSOURCEMAPS = "createCssSourceMaps"
 SETTING_AUTOPREFIX = "autoprefix"
+SETTING_DISABLEVERBOSE = 'disableVerbose'
 
 
 class Compiler:
@@ -76,7 +77,12 @@ class Compiler:
             'autoprefix': project_settings.get(
                 SETTING_AUTOPREFIX,
                 settings.get(SETTING_AUTOPREFIX)
-            )
+            ),
+            'disable_verbose': project_settings.get(
+                SETTING_DISABLEVERBOSE,
+                settings.get(SETTING_DISABLEVERBOSE)
+            ),
+
         }
 
         # Get the filename and encode accordingly.
@@ -198,7 +204,7 @@ class Compiler:
 
     # do convert
     def convertLess2Css(self, lessc_command, dirs, less_file=''):
-        args = ['--verbose']
+        args = []
 
         # get the current file & its css variant
         # if no file was specified take the file name if the current view
@@ -276,6 +282,11 @@ class Compiler:
         if self.settings['autoprefix']:
             args.append('--autoprefix')
             print('[less2css] add prefixes to {}'.format(css_file_name))
+
+        # you must opt in to disable this option
+        if not self.settings['disable_verbose']:
+            args.append('--verbose')
+            print('[less2css] Using verbose mode')
 
         print("[less2css] Converting " + less_file + " to " + css_file_name)
 


### PR DESCRIPTION
Added option disableVerbose which can turn off the verbose flag