### PR TITLE
fix auto compile and main_file not empty

### DIFF
--- a/lesscompiler.py
+++ b/lesscompiler.py
@@ -213,7 +213,7 @@ class Compiler:
             less_file = self.file_name
 
         # if the file name doesn't end on .less, stop processing it
-        if not less_file.endswith(".less"):
+        if not self.view.file_name().endswith(".less"):
             return ''
 
         css_file_name = self.output_file_name(less_file)


### PR DESCRIPTION
If "main_file" is not empty then that setting come to "less_file". As result it will recompile main less file on every save of any file, even non ".less".